### PR TITLE
Support duckspatial native GeoArrow streams

### DIFF
--- a/R/addSource.R
+++ b/R/addSource.R
@@ -3,7 +3,7 @@
 #' @param map the [mapgl::maplibre()] or [mapgl::mapboxgl()] map to add the
 #' data source to.
 #' @param id a unique `ID` for the data source.
-#' @param data a `sf`, `wk`, `geos` or `SpatVector` object.
+#' @param data a `sf`, `wk`, `geos`, `SpatVector` or `duckspatial_df` object.
 #' @param file a valid local file path to a `geoarrow` or `geoparquet` file to be
 #' added to the map. Ignored if `data` is supplied.
 #' @param url a URL to a remotely hosted `geoarrow` or `geoparquet` file to be
@@ -33,6 +33,23 @@
 #' ## open the map in the browser, press <Ctrl+u> and look for a line like this:
 #' ## <link id="pt-geoarrowWidget-attachment" rel="attachment" href="lib/pt-0.0.1/pt.arrow"/>
 #' m
+#'
+#' @tests tinytest
+#'
+#' stream_method = function(x, ..., native = FALSE) native
+#' registerS3method(
+#'   "as_nanoarrow_array_stream"
+#'   , "deckglgeoarrow_test_duckspatial_df"
+#'   , stream_method
+#'   , envir = asNamespace("nanoarrow")
+#' )
+#'
+#' data = structure(
+#'   list()
+#'   , class = c("deckglgeoarrow_test_duckspatial_df", "duckspatial_df")
+#' )
+#'
+#' expect_identical(deckglgeoarrow:::parseGeoarrow(data), TRUE)
 #'
 #' @export
 #'

--- a/R/internals.R
+++ b/R/internals.R
@@ -15,6 +15,10 @@ parseGeoarrow = function(
     return(data)
   }
 
+  if (inherits(data, "duckspatial_df")) {
+    return(nanoarrow::as_nanoarrow_array_stream(data, native = TRUE))
+  }
+
   if (inherits(data, "SpatVector")) {
     stopifnot(
       "need package 'terra' to handle 'SpatVector'" =

--- a/inst/tinytest/test-addSource.R
+++ b/inst/tinytest/test-addSource.R
@@ -1,0 +1,19 @@
+# File created by roxut; edit the function definition file, not this file
+
+# Test found in addSource.R:37 (file:line)
+  
+
+stream_method = function(x, ..., native = FALSE) native
+registerS3method(
+  "as_nanoarrow_array_stream"
+  , "deckglgeoarrow_test_duckspatial_df"
+  , stream_method
+  , envir = asNamespace("nanoarrow")
+)
+
+data = structure(
+  list()
+  , class = c("deckglgeoarrow_test_duckspatial_df", "duckspatial_df")
+)
+
+expect_identical(deckglgeoarrow:::parseGeoarrow(data), TRUE)

--- a/man/addSource.Rd
+++ b/man/addSource.Rd
@@ -12,7 +12,7 @@ data source to.}
 
 \item{id}{a unique \code{ID} for the data source.}
 
-\item{data}{a \code{sf}, \code{wk}, \code{geos} or \code{SpatVector} object.}
+\item{data}{a \code{sf}, \code{wk}, \code{geos}, \code{SpatVector} or \code{duckspatial_df} object.}
 
 \item{file}{a valid local file path to a \code{geoarrow} or \code{geoparquet} file to be
 added to the map. Ignored if \code{data} is supplied.}


### PR DESCRIPTION
## Summary

Adds direct support for `duckspatial_df` objects.

When `addSource()` receives a `duckspatial_df`, it requests DuckSpatial's native GeoArrow representation. This lets users pass lazy DuckDB spatial query results directly to a Deck.gl layer without first collecting an `sf` object or manually converting WKB geometries.

This depends on https://github.com/Cidree/duckspatial/pull/150, which fixes `native = TRUE` to produce native GeoArrow Point, LineString, and Polygon layouts.

## Example

```r
library(duckspatial)
library(mapgl)
library(deckglgeoarrow)

countries <- ddbs_open_dataset(
  system.file(
    "spatial/countries.geojson",
    package = "duckspatial"
  )
)

maplibre(projection = "mercator") |>
  addGeoArrowPolygonLayer(
    data = countries,
    geom_column_name = attr(countries, "sf_column"),
    tooltip = "NAME_ENGL"
  )
```

Users do not need to set `native = TRUE`; `deckglgeoarrow` selects that conversion automatically.

The included test checks that `duckspatial_df` inputs use the native GeoArrow path without adding DuckSpatial as a package dependency.
